### PR TITLE
Remove dash function

### DIFF
--- a/lib/license_plate_pt.ex
+++ b/lib/license_plate_pt.ex
@@ -57,6 +57,7 @@ defmodule LicensePlatePT do
   defdelegate fill_partial(partial_license_plate), to: LicensePlatePT.Manipulation
 
   defdelegate add_dash(license_plate), to: LicensePlatePT.Manipulation
+  defdelegate remove_dash(license_plate), to: LicensePlatePT.Manipulation
 
   defdelegate get_middle_between(license_plate1, license_plate2),
     to: LicensePlatePT.Manipulation

--- a/lib/manipulation.ex
+++ b/lib/manipulation.ex
@@ -25,22 +25,47 @@ defmodule LicensePlatePT.Manipulation do
 
   ## Examples
 
-    iex> LicensePlatePT.add_dash("AB01DF")
+    iex> LicensePlatePT.Manipulation.add_dash("AB01DF")
     "AB-01-DF"
 
-    iex> LicensePlatePT.add_dash("AB-01-DF")
+    iex> LicensePlatePT.Manipulation.add_dash("AB-01-DF")
     "AB-01-DF"
 
-    iex> LicensePlatePT.add_dash("dsds")
+    iex> LicensePlatePT.Manipulation.add_dash("dsds")
     nil
   """
   def add_dash(license_plate) do
-    if valid?(license_plate) || valid_partial?(license_plate) do
+    if valid?(license_plate) or valid_partial?(license_plate) do
       case String.split(license_plate, "", trim: true) do
         [a, b, c, d, e, f] -> String.upcase("#{a}#{b}-#{c}#{d}-#{e}#{f}")
         [_, _, "-", _, _, "-", _, _] -> String.upcase(license_plate)
         _ -> nil
       end
+    else
+      nil
+    end
+  end
+
+  @doc """
+  Remove dash from a license plate. If an invalid license plate is provided, `nil` is returned.
+
+  ## Examples 
+
+    iex > LicensePlatePT.Manipulation.remove_dash("AB01DF")
+    "AB01DF"
+
+    iex > LicensePlatePT.Manipulation.remove_dash("AB-01-DF")
+    "AB01DF"
+
+    iex > LicensePlatePT.Manipulation.remove_dash("ds")
+    nil 
+  """
+  def remove_dash(license_plate) do
+    if valid?(license_plate) or valid_partial?(license_plate) do
+      license_plate
+      |> String.trim()
+      |> String.upcase()
+      |> String.replace("-", "")
     else
       nil
     end

--- a/test/manipulation_test.exs
+++ b/test/manipulation_test.exs
@@ -2,7 +2,7 @@ defmodule LicensePlatePT.ManipulationTest do
   @moduledoc false
 
   @subject LicensePlatePT.Manipulation
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest @subject
 
   describe "add_dash" do
@@ -20,6 +20,24 @@ defmodule LicensePlatePT.ManipulationTest do
 
     test "nil" do
       assert is_nil(@subject.add_dash(nil))
+    end
+  end
+
+  describe "remove_dash" do
+    test "undashed license plate" do
+      assert "AD5433" == @subject.remove_dash("AD5433")
+    end
+
+    test "undashed lower case license plate" do
+      assert "AD5433" == @subject.remove_dash("ad-54-33")
+    end
+
+    test "dashed license plate" do
+      assert "AD5433" == @subject.remove_dash("AD-54-33")
+    end
+
+    test "nil" do
+      assert is_nil(@subject.remove_dash(nil))
     end
   end
 


### PR DESCRIPTION
Since we have `add_dash` we need `remove_dash` to remove dash when in some cases a license plate sould be provided without them.